### PR TITLE
修复无法访问HelloWorld问题

### DIFF
--- a/src/example/helloworld.go
+++ b/src/example/helloworld.go
@@ -34,7 +34,7 @@ func main()  {
 	}
 
 	//访问HelloWorld001模块的HD_Say函数
-	msg, err := this.Request("HelloWorld@HelloWorld001/HD_Say", []byte(`{"say":"我是梁大帅"}`))
+	msg, err := this.Request("HelloWorld/HD_Say", []byte(`{"say":"我是梁大帅"}`))
 	if err != nil {
 		fmt.Println(err.Error())
 	}


### PR DESCRIPTION
由于模块在注册到Consul时，使用的是随机生成的ID，代码如下：
if len(opts.Id) == 0 {
	opt = append(opt, server.Id(utils.GenerateID().String()))
}
所以指定HelloWorld001将无法访问成功